### PR TITLE
Cancel playInfoStream on dispose()

### DIFF
--- a/lib/src/video360_controller.dart
+++ b/lib/src/video360_controller.dart
@@ -52,6 +52,7 @@ class Video360Controller {
 
   dispose() async {
     try {
+      playInfoStream?.cancel();
       await _channel.invokeMethod<void>('dispose');
     } on PlatformException catch (e) {
       print('${e.code}: ${e.message}');


### PR DESCRIPTION
`playInfoStream` keeps running in the background after disposing player.

### How to reproduce:
1. Clone this [example repository](https://github.com/irvine5k/example_video_360_bug) or paste [this](https://gist.github.com/irvine5k/c2b2e668af8a4694dfff5bb27d84a85f) at `example/main.dart`
2. Run main.dart
3. Navigate to player
4. Navigate back
5. You should find something similar in the logs:
```bash
[ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: setState() called after dispose(): _MyAppState#8c8f2(lifecycle state: defunct, not mounted)
E/flutter (13910): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
E/flutter (13910): The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter (13910): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().
E/flutter (13910): #0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1085:9)
E/flutter (13910): #1      State.setState (package:flutter/src/widgets/framework.dart:1120:6)
E/flutter (13910): #2      _MyAppState.build.<anonymous closure> (package:pr_android_bug/main.dart:47:19)
E/flutter (13910): #3      Video360Controller.updateTime.<anonymous closure> (package:video_360/src/video360_controller.dart:160:21)
E/flutter (13910): <asynchronous suspension>
E/flutter (13910):
```


### Specs:
```bash
Flutter 2.10.5 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 5464c5bac7 (3 months ago) • 2022-04-18 09:55:37 -0700
Engine • revision 57d3bac3dd
Tools • Dart 2.16.2 • DevTools 2.9.2
```

### Device:
```bash
Android 12 (API 32) (emulator)
```

### Flutter Doctor:
```bash
Doctor summary (to see all details, run flutter doctor -v):
[✓] Flutter (Channel stable, 2.10.5, on macOS 12.2.1 21D62 darwin-arm, locale en-BR)
[✓] Android toolchain - develop for Android devices (Android SDK version 32.1.0-rc1)
[✓] Xcode - develop for iOS and macOS (Xcode 13.3.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2021.1)
[✓] IntelliJ IDEA Community Edition (version 2022.1)
[✓] IntelliJ IDEA Community Edition (version 2022.1.3)
[✓] VS Code (version 1.67.2)
[✓] Connected device (4 available)
[✓] HTTP Host Availability

• No issues found!
```